### PR TITLE
feat: Support custom drive to prevent using prefix in the file name

### DIFF
--- a/src/scheduler/NotebookScheduler.tsx
+++ b/src/scheduler/NotebookScheduler.tsx
@@ -96,7 +96,9 @@ const NotebookSchedulerComponent = ({
       const currentTime = new Date().getTime();
       const formattedCurrentTime = formatTimestamp(currentTime);
       setJobNameSelected(`job_${formattedCurrentTime}`);
-      setInputFileSelected(context.path);
+      setInputFileSelected(
+        app.serviceManager.contents.localPath(context.localPath)
+      );
     }
   }, [notebookSelector]);
 

--- a/src/scheduler/composer/CreateNotebookScheduler.tsx
+++ b/src/scheduler/composer/CreateNotebookScheduler.tsx
@@ -541,7 +541,9 @@ const CreateNotebookScheduler = ({
    */
   useEffect(() => {
     if (context !== '') {
-      setInputFileSelected(context.path);
+      setInputFileSelected(
+        app.serviceManager.contents.localPath(context.localPath)
+      );
     }
     setJobNameSelected('');
     if (!editMode) {


### PR DESCRIPTION
Modifying the context.path that provides the file path to the file name input to support custom drive.

Why? Certain plugin like jupyter-collaboration adds some prefix to file path (ex: RTC:<filename>) which breaks the Scheduler and returns a file not found.