### PR TITLE
Add runtime image and shielded vm option to frontend

### DIFF
--- a/scheduler_jupyter_plugin/models/models.py
+++ b/scheduler_jupyter_plugin/models/models.py
@@ -86,6 +86,15 @@ class DescribeVertexJob(BaseModel):
     disk_size: str = None
     kms_key_name: Optional[str] = None
     enable_public_ip: Optional[bool] = True
+    # Workbench runtime image environment (VM image family or custom container).
+    vm_image_project: Optional[str] = None
+    vm_image_family: Optional[str] = None
+    custom_container_repository: Optional[str] = None
+    custom_container_tag: Optional[str] = None
+    # Shielded VM options for the execution VM.
+    enable_secure_boot: Optional[bool] = False
+    enable_vtpm: Optional[bool] = False
+    enable_integrity_monitoring: Optional[bool] = False
 
     @classmethod
     def from_dict(cls, data):
@@ -123,6 +132,15 @@ class DescribeUpdateVertexJob(BaseModel):
     disk_size: Optional[str] = None
     kms_key_name: Optional[str] = None
     enable_public_ip: Optional[bool] = True
+    # Workbench runtime image environment (VM image family or custom container).
+    vm_image_project: Optional[str] = None
+    vm_image_family: Optional[str] = None
+    custom_container_repository: Optional[str] = None
+    custom_container_tag: Optional[str] = None
+    # Shielded VM options for the execution VM.
+    enable_secure_boot: Optional[bool] = False
+    enable_vtpm: Optional[bool] = False
+    enable_integrity_monitoring: Optional[bool] = False
 
     @classmethod
     def from_dict(cls, data):

--- a/scheduler_jupyter_plugin/services/vertex.py
+++ b/scheduler_jupyter_plugin/services/vertex.py
@@ -102,6 +102,41 @@ class Client:
 
         return blob_name if blob_name else file_path
 
+    def _build_workbench_runtime(self, job):
+        """Builds the workbenchRuntime image environment from the job request.
+
+        Returns a dict with either a `vmImage` (project + image family, matching
+        the Workbench "latest in a family" workflow) or a `customContainerImage`
+        (repository + optional tag). When neither is set, an empty dict is
+        returned so the service uses its default managed image.
+        """
+        workbench_runtime = {}
+        if job.vm_image_project:
+            vm_image = {"project": job.vm_image_project}
+            if job.vm_image_family:
+                vm_image["family"] = job.vm_image_family
+            workbench_runtime["vmImage"] = vm_image
+        elif job.custom_container_repository:
+            container_image = {"repository": job.custom_container_repository}
+            if job.custom_container_tag:
+                container_image["tag"] = job.custom_container_tag
+            workbench_runtime["customContainerImage"] = container_image
+        return workbench_runtime
+
+    def _build_shielded_instance_config(self, job):
+        """Builds the Shielded VM config, or None when all options are disabled."""
+        if (
+            job.enable_secure_boot
+            or job.enable_vtpm
+            or job.enable_integrity_monitoring
+        ):
+            return {
+                "enableSecureBoot": job.enable_secure_boot,
+                "enableVtpm": job.enable_vtpm,
+                "enableIntegrityMonitoring": job.enable_integrity_monitoring,
+            }
+        return None
+
     async def create_schedule(self, job, file_path, bucket_name):
         try:
             schedule_value = (
@@ -123,6 +158,8 @@ class Client:
             notebook_source = (
                 file_path if "gs://" in file_path else f"gs://{bucket_name}/{file_path}"
             )
+
+            workbench_runtime = self._build_workbench_runtime(job)
 
             api_endpoint = f"https://{job.region}-aiplatform.googleapis.com/v1/projects/{self.project_id}/locations/{job.region}/schedules"
             headers = self.create_headers()
@@ -154,10 +191,15 @@ class Client:
                         "gcsOutputUri": job.cloud_storage_bucket,
                         "serviceAccount": job.service_account,
                         "kernelName": job.kernel_name,
-                        "workbenchRuntime": {},
+                        "workbenchRuntime": workbench_runtime,
                     },
                 },
             }
+            shielded_instance_config = self._build_shielded_instance_config(job)
+            if shielded_instance_config:
+                payload["createNotebookExecutionJobRequest"]["notebookExecutionJob"][
+                    "customEnvironmentSpec"
+                ]["shieldedInstanceConfig"] = shielded_instance_config
             if job.max_run_count:
                 payload["maxRunCount"] = job.max_run_count
             if job.start_time:
@@ -487,7 +529,7 @@ class Client:
                 "labels": {
                     "aiplatform.googleapis.com/colab_enterprise_entry_service": "workbench",
                 },
-                "workbenchRuntime": {},
+                "workbenchRuntime": self._build_workbench_runtime(data),
             }
             schedule_value = (
                 "* * * * *" if data.schedule_value == "" else data.schedule_value
@@ -531,6 +573,11 @@ class Client:
                     "diskSizeGb": data.disk_size,
                     "diskType": data.disk_type.split(" ", 1)[0],
                 }
+            shielded_instance_config = self._build_shielded_instance_config(data)
+            if shielded_instance_config:
+                custom_environment_spec["shieldedInstanceConfig"] = (
+                    shielded_instance_config
+                )
 
             payload = {
                 "displayName": data.display_name,

--- a/scheduler_jupyter_plugin/tests/test_vertex.py
+++ b/scheduler_jupyter_plugin/tests/test_vertex.py
@@ -19,6 +19,10 @@ import aiohttp
 
 import pytest
 
+from scheduler_jupyter_plugin.models.models import (
+    DescribeUpdateVertexJob,
+    DescribeVertexJob,
+)
 from scheduler_jupyter_plugin.services import vertex
 from scheduler_jupyter_plugin.tests.mocks import (
     MockDeleteSchedulesClientSession,
@@ -291,3 +295,96 @@ class TestCreateNewBucketMethod(unittest.TestCase):
         result = await self.instance.create_new_bucket(self.input_data)
 
         self.assertEqual(result, {})
+
+
+def _make_client():
+    return vertex.Client(
+        {
+            "access_token": "mock-token",
+            "project_id": "mock-project",
+            "region_id": "mock-region",
+        },
+        MagicMock(),
+        MagicMock(),
+    )
+
+
+class TestBuildWorkbenchRuntime(unittest.TestCase):
+    def setUp(self):
+        self.client = _make_client()
+
+    def test_default_image_returns_empty(self):
+        self.assertEqual(
+            self.client._build_workbench_runtime(DescribeVertexJob()), {}
+        )
+
+    def test_vm_image_with_family(self):
+        job = DescribeVertexJob(vm_image_project="proj", vm_image_family="fam")
+        self.assertEqual(
+            self.client._build_workbench_runtime(job),
+            {"vmImage": {"project": "proj", "family": "fam"}},
+        )
+
+    def test_custom_container_with_tag(self):
+        job = DescribeVertexJob(
+            custom_container_repository="gcr.io/p/i",
+            custom_container_tag="v1",
+        )
+        self.assertEqual(
+            self.client._build_workbench_runtime(job),
+            {"customContainerImage": {"repository": "gcr.io/p/i", "tag": "v1"}},
+        )
+
+    def test_custom_container_without_tag(self):
+        job = DescribeVertexJob(custom_container_repository="gcr.io/p/i")
+        self.assertEqual(
+            self.client._build_workbench_runtime(job),
+            {"customContainerImage": {"repository": "gcr.io/p/i"}},
+        )
+
+
+class TestBuildShieldedInstanceConfig(unittest.TestCase):
+    def setUp(self):
+        self.client = _make_client()
+
+    def test_all_disabled_returns_none(self):
+        self.assertIsNone(
+            self.client._build_shielded_instance_config(DescribeVertexJob())
+        )
+
+    def test_secure_boot_only(self):
+        job = DescribeVertexJob(enable_secure_boot=True)
+        self.assertEqual(
+            self.client._build_shielded_instance_config(job),
+            {
+                "enableSecureBoot": True,
+                "enableVtpm": False,
+                "enableIntegrityMonitoring": False,
+            },
+        )
+
+    def test_all_enabled(self):
+        job = DescribeVertexJob(
+            enable_secure_boot=True,
+            enable_vtpm=True,
+            enable_integrity_monitoring=True,
+        )
+        self.assertEqual(
+            self.client._build_shielded_instance_config(job),
+            {
+                "enableSecureBoot": True,
+                "enableVtpm": True,
+                "enableIntegrityMonitoring": True,
+            },
+        )
+
+    def test_supports_update_model(self):
+        data = DescribeUpdateVertexJob(enable_vtpm=True)
+        self.assertEqual(
+            self.client._build_shielded_instance_config(data),
+            {
+                "enableSecureBoot": False,
+                "enableVtpm": True,
+                "enableIntegrityMonitoring": False,
+            },
+        )

--- a/src/scheduler/vertex/CreateVertexScheduler.tsx
+++ b/src/scheduler/vertex/CreateVertexScheduler.tsx
@@ -50,11 +50,15 @@ import {
   DEFAULT_DISK_MIN_SIZE,
   DEFAULT_DISK_SIZE,
   DEFAULT_ENCRYPTION_SELECTED,
+  DEFAULT_IMAGE_ENVIRONMENT,
   DEFAULT_KERNEL,
   DEFAULT_MACHINE_TYPE,
   DEFAULT_SERVICE_ACCOUNT,
   DISK_TYPE_VALUE,
   everyMinuteCron,
+  IMAGE_ENVIRONMENT_CONTAINER,
+  IMAGE_ENVIRONMENT_DEFAULT,
+  IMAGE_ENVIRONMENT_VM_IMAGE,
   internalScheduleMode,
   KERNEL_VALUE,
   KEY_MESSAGE,
@@ -62,6 +66,7 @@ import {
   scheduleValueExpression,
   SECURITY_KEY,
   SHARED_NETWORK_DOC_URL,
+  SHIELDED_VM_DOC_URL,
   SUBNETWORK_VERTEX_ERROR,
   VERTEX_REGIONS,
   VERTEX_SCHEDULE
@@ -241,6 +246,21 @@ const CreateVertexScheduler = ({
   const [cryptoKeyLoading, setCryptoKeyLoading] = useState<boolean>(false);
   const [keyRingListLoading, setKeyRingListLoading] = useState<boolean>(false);
 
+  // Workbench runtime image environment selection and values (Default/VM/Container).
+  const [imageEnvironmentSelected, setImageEnvironmentSelected] =
+    useState<string>(DEFAULT_IMAGE_ENVIRONMENT);
+  const [vmImageProject, setVmImageProject] = useState<string>('');
+  const [vmImageFamily, setVmImageFamily] = useState<string>('');
+  const [customContainerRepository, setCustomContainerRepository] =
+    useState<string>('');
+  const [customContainerTag, setCustomContainerTag] = useState<string>('');
+
+  // Shielded VM options for the execution VM (all disabled by default).
+  const [enableSecureBoot, setEnableSecureBoot] = useState<boolean>(false);
+  const [enableVtpm, setEnableVtpm] = useState<boolean>(false);
+  const [enableIntegrityMonitoring, setEnableIntegrityMonitoring] =
+    useState<boolean>(false);
+
   /**
    * Changing the region value and empyting the value of machineType, accelratorType and accelratorCount
    * @param {string} value selected region
@@ -291,6 +311,26 @@ const CreateVertexScheduler = ({
   const handleDefaultDiskSize = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value === '') {
       setDiskSize('100');
+    }
+  };
+
+  /**
+   * Handles runtime image environment selection and clears fields that are not
+   * relevant to the newly selected option.
+   * @param {React.ChangeEvent<HTMLInputElement>} event - The change event triggered by the radio button field.
+   */
+  const handleImageEnvironmentChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const newValue = event.target.value;
+    setImageEnvironmentSelected(newValue);
+    if (newValue !== IMAGE_ENVIRONMENT_VM_IMAGE) {
+      setVmImageProject('');
+      setVmImageFamily('');
+    }
+    if (newValue !== IMAGE_ENVIRONMENT_CONTAINER) {
+      setCustomContainerRepository('');
+      setCustomContainerTag('');
     }
   };
 
@@ -843,7 +883,11 @@ const CreateVertexScheduler = ({
           cryptoKeySelected === '' ||
           cryptoKeyLoading) &&
         manualKeySelected === '') ||
-      !manualValidation
+      !manualValidation ||
+      (imageEnvironmentSelected === IMAGE_ENVIRONMENT_VM_IMAGE &&
+        (vmImageProject.trim() === '' || vmImageFamily.trim() === '')) ||
+      (imageEnvironmentSelected === IMAGE_ENVIRONMENT_CONTAINER &&
+        customContainerRepository.trim() === '')
     );
   };
 
@@ -914,6 +958,22 @@ const CreateVertexScheduler = ({
           ? `projects/${projectId}/locations/${region}/keyRings/${keyRingSelected}/cryptoKeys/${cryptoKeySelected}`
           : manualKeySelected;
     }
+
+    // Workbench runtime image environment (VM image family or custom container).
+    if (imageEnvironmentSelected === IMAGE_ENVIRONMENT_VM_IMAGE) {
+      payload.vm_image_project = vmImageProject.trim();
+      payload.vm_image_family = vmImageFamily.trim();
+    } else if (imageEnvironmentSelected === IMAGE_ENVIRONMENT_CONTAINER) {
+      payload.custom_container_repository = customContainerRepository.trim();
+      if (customContainerTag.trim()) {
+        payload.custom_container_tag = customContainerTag.trim();
+      }
+    }
+
+    // Shielded VM options (only enabled ones are acted on by the backend).
+    payload.enable_secure_boot = enableSecureBoot;
+    payload.enable_vtpm = enableVtpm;
+    payload.enable_integrity_monitoring = enableIntegrityMonitoring;
 
     if (editMode) {
       await VertexServices.editVertexJobSchedulerService(
@@ -1074,6 +1134,30 @@ const CreateVertexScheduler = ({
       setDiskSize(vertexSchedulerDetails.disk_size);
       setGcsPath(vertexSchedulerDetails.gcs_notebook_source ?? '');
       setEnablePublicIp(vertexSchedulerDetails.enable_public_ip ?? true);
+
+      // Load Workbench runtime image environment.
+      if (vertexSchedulerDetails.vm_image_project) {
+        setImageEnvironmentSelected(IMAGE_ENVIRONMENT_VM_IMAGE);
+        setVmImageProject(vertexSchedulerDetails.vm_image_project);
+        setVmImageFamily(vertexSchedulerDetails.vm_image_family ?? '');
+      } else if (vertexSchedulerDetails.custom_container_repository) {
+        setImageEnvironmentSelected(IMAGE_ENVIRONMENT_CONTAINER);
+        setCustomContainerRepository(
+          vertexSchedulerDetails.custom_container_repository
+        );
+        setCustomContainerTag(
+          vertexSchedulerDetails.custom_container_tag ?? ''
+        );
+      } else {
+        setImageEnvironmentSelected(IMAGE_ENVIRONMENT_DEFAULT);
+      }
+
+      // Load Shielded VM options.
+      setEnableSecureBoot(vertexSchedulerDetails.enable_secure_boot ?? false);
+      setEnableVtpm(vertexSchedulerDetails.enable_vtpm ?? false);
+      setEnableIntegrityMonitoring(
+        vertexSchedulerDetails.enable_integrity_monitoring ?? false
+      );
 
       if ('kms_key_name' in vertexSchedulerDetails) {
         if (vertexSchedulerDetails.kms_key_name) {
@@ -1461,6 +1545,187 @@ const CreateVertexScheduler = ({
                 />
               )}
             </div>
+          </div>
+
+          <div className="create-job-scheduler-text-para create-job-scheduler-sub-title">
+            Runtime image
+          </div>
+
+          <p>
+            Select the image environment for the Workbench runtime. Defaults to
+            the managed Workbench image if left unset.
+          </p>
+
+          <div className="create-scheduler-form-element panel-margin">
+            <FormControl>
+              <RadioGroup
+                aria-labelledby="image-environment-radio-buttons-group"
+                name="image-environment-radio-buttons-group"
+                value={imageEnvironmentSelected}
+                onChange={handleImageEnvironmentChange}
+                data-testid={`${imageEnvironmentSelected}-image-selected`}
+              >
+                <FormControlLabel
+                  value={IMAGE_ENVIRONMENT_DEFAULT}
+                  className="create-scheduler-label-style"
+                  control={<Radio size="small" />}
+                  label={
+                    <Typography sx={{ fontSize: 13 }}>Default image</Typography>
+                  }
+                />
+                <FormControlLabel
+                  value={IMAGE_ENVIRONMENT_VM_IMAGE}
+                  className="create-scheduler-label-style"
+                  control={<Radio size="small" />}
+                  label={
+                    <Typography sx={{ fontSize: 13 }}>
+                      Compute Engine VM image
+                    </Typography>
+                  }
+                />
+                <FormControlLabel
+                  value={IMAGE_ENVIRONMENT_CONTAINER}
+                  className="create-scheduler-label-style"
+                  control={<Radio size="small" />}
+                  label={
+                    <Typography sx={{ fontSize: 13 }}>
+                      Custom container image
+                    </Typography>
+                  }
+                />
+              </RadioGroup>
+            </FormControl>
+          </div>
+
+          {imageEnvironmentSelected === IMAGE_ENVIRONMENT_VM_IMAGE && (
+            <>
+              <div className="create-scheduler-form-element">
+                <Input
+                  className="create-scheduler-style"
+                  value={vmImageProject}
+                  onChange={e => setVmImageProject(e.target.value)}
+                  type="text"
+                  placeholder=""
+                  Label="Image project*"
+                />
+                {vmImageProject.trim() === '' && (
+                  <ErrorMessage
+                    message="Image project is required"
+                    showIcon={false}
+                  />
+                )}
+                <span className="tab-description tab-text-sub-cl">
+                  For example: cloud-notebooks-managed
+                </span>
+              </div>
+              <div className="create-scheduler-form-element">
+                <Input
+                  className="create-scheduler-style"
+                  value={vmImageFamily}
+                  onChange={e => setVmImageFamily(e.target.value)}
+                  type="text"
+                  placeholder=""
+                  Label="Image family*"
+                />
+                {vmImageFamily.trim() === '' && (
+                  <ErrorMessage
+                    message="Image family is required"
+                    showIcon={false}
+                  />
+                )}
+                <span className="tab-description tab-text-sub-cl">
+                  For example: workbench-instances-2603 (newest image in the
+                  family is used)
+                </span>
+              </div>
+            </>
+          )}
+
+          {imageEnvironmentSelected === IMAGE_ENVIRONMENT_CONTAINER && (
+            <>
+              <div className="create-scheduler-form-element">
+                <Input
+                  className="create-scheduler-style"
+                  value={customContainerRepository}
+                  onChange={e => setCustomContainerRepository(e.target.value)}
+                  type="text"
+                  placeholder=""
+                  Label="Container image repository*"
+                />
+                {customContainerRepository.trim() === '' && (
+                  <ErrorMessage
+                    message="Container image repository is required"
+                    showIcon={false}
+                  />
+                )}
+                <span className="tab-description tab-text-sub-cl">
+                  For example:
+                  us-docker.pkg.dev/workbench-images/gcr.io/workbench-container-2606
+                </span>
+              </div>
+              <div className="create-scheduler-form-element">
+                <Input
+                  className="create-scheduler-style"
+                  value={customContainerTag}
+                  onChange={e => setCustomContainerTag(e.target.value)}
+                  type="text"
+                  placeholder="latest"
+                  Label="Container image tag"
+                />
+                <span className="tab-description tab-text-sub-cl">
+                  If unset, defaults to "latest".
+                </span>
+              </div>
+            </>
+          )}
+
+          <div className="create-job-scheduler-text-para create-job-scheduler-sub-title">
+            Shielded VM options
+          </div>
+
+          <p>Configure Shielded VM security options for the execution VM.</p>
+
+          <div className="create-scheduler-form-element">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={enableSecureBoot}
+                  onChange={e => setEnableSecureBoot(e.target.checked)}
+                />
+              }
+              label={
+                <Typography variant="body2">Enable Secure Boot</Typography>
+              }
+            />
+          </div>
+          <div className="create-scheduler-form-element">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={enableVtpm}
+                  onChange={e => setEnableVtpm(e.target.checked)}
+                />
+              }
+              label={<Typography variant="body2">Enable vTPM</Typography>}
+            />
+          </div>
+          <div className="create-scheduler-form-element">
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={enableIntegrityMonitoring}
+                  onChange={e => setEnableIntegrityMonitoring(e.target.checked)}
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  Enable integrity monitoring
+                </Typography>
+              }
+            />
+          </div>
+          <div className="learn-more-a-tag learn-more-url">
+            <LearnMore path={SHIELDED_VM_DOC_URL} />
           </div>
 
           <div className="create-scheduler-form-element panel-margin block-seperation">

--- a/src/scheduler/vertex/VertexInterfaces.ts
+++ b/src/scheduler/vertex/VertexInterfaces.ts
@@ -55,6 +55,15 @@ export interface ICreatePayload {
   gcs_notebook_source?: string;
   kms_key_name?: string;
   enable_public_ip?: boolean;
+  // Workbench runtime image environment (mutually exclusive: VM image family vs container).
+  vm_image_project?: string;
+  vm_image_family?: string;
+  custom_container_repository?: string;
+  custom_container_tag?: string;
+  // Shielded VM options for the execution VM.
+  enable_secure_boot?: boolean;
+  enable_vtpm?: boolean;
+  enable_integrity_monitoring?: boolean;
 }
 export interface IVertexScheduleList {
   displayName: string;

--- a/src/services/Vertex.tsx
+++ b/src/services/Vertex.tsx
@@ -688,6 +688,36 @@ export class VertexServices {
               ? true
               : false
         };
+
+        // Load Workbench runtime image environment (VM image family or container).
+        const workbenchRuntime =
+          formattedResponse.createNotebookExecutionJobRequest
+            .notebookExecutionJob.workbenchRuntime;
+        if (workbenchRuntime?.vmImage) {
+          scheduleDetails.vm_image_project = workbenchRuntime.vmImage.project;
+          scheduleDetails.vm_image_family = workbenchRuntime.vmImage.family;
+        } else if (workbenchRuntime?.customContainerImage) {
+          scheduleDetails.custom_container_repository =
+            workbenchRuntime.customContainerImage.repository;
+          if (workbenchRuntime.customContainerImage.tag) {
+            scheduleDetails.custom_container_tag =
+              workbenchRuntime.customContainerImage.tag;
+          }
+        }
+
+        // Load Shielded VM options.
+        const shieldedInstanceConfig =
+          formattedResponse.createNotebookExecutionJobRequest
+            .notebookExecutionJob.customEnvironmentSpec?.shieldedInstanceConfig;
+        if (shieldedInstanceConfig) {
+          scheduleDetails.enable_secure_boot =
+            shieldedInstanceConfig.enableSecureBoot ?? false;
+          scheduleDetails.enable_vtpm =
+            shieldedInstanceConfig.enableVtpm ?? false;
+          scheduleDetails.enable_integrity_monitoring =
+            shieldedInstanceConfig.enableIntegrityMonitoring ?? false;
+        }
+
         setCreateCompleted(false);
         setRegion(region);
 

--- a/src/utils/Const.ts
+++ b/src/utils/Const.ts
@@ -185,6 +185,18 @@ export const DEFAULT_CUSTOMER_MANAGED_SELECTION = 'key';
 export const KEY_MESSAGE =
   'Example format:projects/<project-name>/locations/<location-name>/keyRings/<keyring-name>/cryptoKeys/<key-name>';
 
+// Runtime image environment selection for the Workbench runtime.
+export const IMAGE_ENVIRONMENT_DEFAULT = 'default';
+export const IMAGE_ENVIRONMENT_VM_IMAGE = 'vmImage';
+export const IMAGE_ENVIRONMENT_CONTAINER = 'customContainer';
+export const DEFAULT_IMAGE_ENVIRONMENT = IMAGE_ENVIRONMENT_DEFAULT;
+
+// Default container image tag applied by the API when none is provided.
+export const DEFAULT_CONTAINER_IMAGE_TAG = 'latest';
+
+export const SHIELDED_VM_DOC_URL =
+  'https://cloud.google.com/compute/docs/instances/modifying-shielded-vm';
+
 export const INPUT_HELPER_TEXT =
   'This schedule will run a copy of this notebook in its current state. If you edit the original notebook, you must create a new schedule to run the updated version of the notebook.';
 export const NO_EXECUTION_FOUND =


### PR DESCRIPTION
# Add Workbench runtime image and Shielded VM options to the Vertex scheduler
## Summary
Extends the Vertex AI scheduler create/edit form to expose newly added
`NotebookExecutionJob` fields so users can control the execution environment:
- **Runtime image** for the Workbench runtime — keep the managed default, or select
  a **Compute Engine VM image** (by image family) or a **custom container image**.
- **Shielded VM options** — Secure Boot, vTPM, and integrity monitoring for the
  execution VM.
These map to the `WorkbenchRuntime.image_environment` (`vm_image` /
`custom_container_image`) and `CustomEnvironmentSpec.shielded_instance_config` API
fields, and are plumbed end-to-end: frontend form → Python server extension →
Vertex AI API request body.
## Changes
### UI (`src/scheduler/vertex/CreateVertexScheduler.tsx`)
- New **Runtime image** section (radio): `Default image` / `Compute Engine VM image` /
  `Custom container image`.
  - VM image → **Image project** + **Image family**. Family-only, matching the
    Vertex AI Workbench "latest image in a family" workflow (no pinned image name).
  - Custom container → **repository** (required) + **tag** (optional; the API
    applies `latest` when unset).
- New **Shielded VM options** section: three checkboxes, all unchecked by default.
- Inline example hints for each field; validation gates the Create/Update button;
  edit mode reloads existing values.
### Plumbing
- `src/scheduler/vertex/VertexInterfaces.ts` — new fields on `ICreatePayload`.
- `src/services/Vertex.tsx` — edit-mode read-back of the new fields.
- `src/utils/Const.ts` — image-environment option constants + Shielded VM doc link.
- `scheduler_jupyter_plugin/models/models.py` — new fields on `DescribeVertexJob`
  and `DescribeUpdateVertexJob`.
- `scheduler_jupyter_plugin/services/vertex.py` — `_build_workbench_runtime` and
  `_build_shielded_instance_config` helpers, wired into both `create_schedule` and
  `update_schedule`.
## Behavior / request mapping
`custom_environment_spec` and `workbench_runtime` live in separate API `oneof`s, so
they coexist (the plugin already sends both). New fields nest as:
| UI selection | Generated `notebookExecutionJob` fields |
|---|---|
| Default image | `workbenchRuntime: {}` (managed default — unchanged) |
| VM image | `workbenchRuntime.vmImage: { project, family }` |
| Custom container | `workbenchRuntime.customContainerImage: { repository, tag? }` |
| Shielded options | `customEnvironmentSpec.shieldedInstanceConfig: { enableSecureBoot, enableVtpm, enableIntegrityMonitoring }` |
- `shieldedInstanceConfig` is only sent when at least one option is enabled.
- An unset image leaves `workbenchRuntime` empty, preserving current behavior.
- **Backward compatible**: existing schedules produce byte-identical requests.
## Testing
- `jlpm build` / `jlpm build:lib` (tsc + webpack): pass
- `jlpm run lint` (prettier / eslint / stylelint): pass
- `python -m pytest`: **48 passed** (includes new unit tests for the request-body helpers)
- Offline request-body validation via `scripts/inspect_vertex_payload.py` (no GCP
  required), confirming the generated Vertex API body per mode:
```
========================================================================
Per-mode summary of the generated NotebookExecutionJob
========================================================================
1) Default image, no shielded options (baseline, unchanged)
  workbenchRuntime       -> {}
  shieldedInstanceConfig -> null
2) VM image family + Secure Boot
  workbenchRuntime       -> {"vmImage": {"project": "cloud-notebooks-managed", "family": "workbench-instances-2603"}}
  shieldedInstanceConfig -> {"enableSecureBoot": true, "enableVtpm": false, "enableIntegrityMonitoring": false}
3) Custom container + tag + all shielded options
  workbenchRuntime       -> {"customContainerImage": {"repository": "us-docker.pkg.dev/workbench-images/gcr.io/workbench-container-2606", "tag": "latest"}}
  shieldedInstanceConfig -> {"enableSecureBoot": true, "enableVtpm": true, "enableIntegrityMonitoring": true}
4) Custom container, no tag (API applies 'latest')
  workbenchRuntime       -> {"customContainerImage": {"repository": "us-docker.pkg.dev/workbench-images/gcr.io/workbench-container-2606"}}
  shieldedInstanceConfig -> null
```
<img width="895" height="599" alt="Screenshot 2026-07-20 at 2 46 13 PM" src="https://github.com/user-attachments/assets/2414fb78-04eb-4cd0-a6ab-5bb5e173eda9" />
<img width="885" height="498" alt="Screenshot 2026-07-20 at 2 47 41 PM" src="https://github.com/user-attachments/assets/40050626-bee6-48b2-8195-158c6e8e6f83" />
<img width="856" height="464" alt="Screenshot 2026-07-20 at 2 47 57 PM" src="https://github.com/user-attachments/assets/ed8fa90d-a9e1-4773-b836-ba8d7f1d8de0" />
