### PR TITLE
[BUG] Validate Vertex region_id to prevent request forgery (SSRF)

### DIFF
--- a/scheduler_jupyter_plugin/commons/constants.py
+++ b/scheduler_jupyter_plugin/commons/constants.py
@@ -54,6 +54,9 @@ BUCKET_NAME_REGEXP = re.compile("[a-z][a-z0-9_.-]{1,61}[a-z0-9]")
 #  output file names.
 DAG_RUN_ID_REGEXP = re.compile("[a-zA-Z0-9_:\\+.-]+")
 
+# Vertex AI region ID, e.g. "us-central1".
+REGION_ID_REGEXP = re.compile("[a-z]+-[a-z]+[0-9]+")
+
 HTTP_STATUS_OK = 200
 HTTP_STATUS_NO_CONTENT = 204
 HTTP_STATUS_FORBIDDEN = 403

--- a/scheduler_jupyter_plugin/services/vertex.py
+++ b/scheduler_jupyter_plugin/services/vertex.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import re
+
 import aiohttp
 import json
 from cron_descriptor import get_description
@@ -25,6 +27,7 @@ from scheduler_jupyter_plugin.commons.constants import (
     HTTP_STATUS_OK,
     HTTP_STATUS_FORBIDDEN,
     HTTP_STATUS_NO_CONTENT,
+    REGION_ID_REGEXP,
 )
 from scheduler_jupyter_plugin.models.models import (
     DescribeVertexJob,
@@ -55,6 +58,13 @@ class Client:
             "Content-Type": CONTENT_TYPE,
             "Authorization": f"Bearer {self._access_token}",
         }
+
+    @staticmethod
+    def _validate_region_id(region_id):
+        """Validate a region ID before it is used to build a request URL."""
+        if not region_id or not re.fullmatch(REGION_ID_REGEXP, region_id):
+            raise ValueError(f"Invalid region ID: {region_id}")
+        return region_id
 
     async def create_gcs_bucket(self, bucket_name):
         try:
@@ -139,6 +149,7 @@ class Client:
 
     async def create_schedule(self, job, file_path, bucket_name):
         try:
+            self._validate_region_id(job.region)
             schedule_value = (
                 "* * * * *" if job.schedule_value == "" else job.schedule_value
             )
@@ -266,6 +277,7 @@ class Client:
 
     async def list_uiconfig(self, region_id):
         try:
+            self._validate_region_id(region_id)
             uiconfig = []
             api_endpoint = f"https://{region_id}-aiplatform.googleapis.com/ui/projects/{self.project_id}/locations/{region_id}/uiConfig"
 
@@ -315,6 +327,7 @@ class Client:
 
     async def list_schedules(self, region_id, page_size=100, next_page_token=None):
         try:
+            self._validate_region_id(region_id)
             result = {}
 
             if next_page_token:
@@ -394,6 +407,7 @@ class Client:
 
     async def pause_schedule(self, region_id, schedule_id):
         try:
+            self._validate_region_id(region_id)
             api_endpoint = (
                 f"https://{region_id}-aiplatform.googleapis.com/v1/{schedule_id}:pause"
             )
@@ -419,6 +433,7 @@ class Client:
 
     async def resume_schedule(self, region_id, schedule_id):
         try:
+            self._validate_region_id(region_id)
             api_endpoint = (
                 f"https://{region_id}-aiplatform.googleapis.com/v1/{schedule_id}:resume"
             )
@@ -444,6 +459,7 @@ class Client:
 
     async def delete_schedule(self, region_id, schedule_id):
         try:
+            self._validate_region_id(region_id)
             api_endpoint = (
                 f"https://{region_id}-aiplatform.googleapis.com/v1/{schedule_id}"
             )
@@ -469,6 +485,7 @@ class Client:
 
     async def get_schedule(self, region_id, schedule_id):
         try:
+            self._validate_region_id(region_id)
             api_endpoint = (
                 f"https://{region_id}-aiplatform.googleapis.com/v1/{schedule_id}"
             )
@@ -492,6 +509,7 @@ class Client:
 
     async def trigger_schedule(self, region_id, schedule_id):
         try:
+            self._validate_region_id(region_id)
             data = await self.get_schedule(region_id, schedule_id)
             api_endpoint = f"https://{region_id}-aiplatform.googleapis.com/v1/projects/{self.project_id}/locations/{region_id}/notebookExecutionJobs"
 
@@ -520,6 +538,7 @@ class Client:
 
     async def update_schedule(self, region_id, schedule_id, input_data):
         try:
+            self._validate_region_id(region_id)
             data = DescribeUpdateVertexJob(**input_data)
             custom_environment_spec = {}
             notebook_execution_job = {
@@ -626,6 +645,7 @@ class Client:
         self, region_id, schedule_id, order_by, page_size=None, start_date=None
     ):
         try:
+            self._validate_region_id(region_id)
             execution_jobs = []
             if page_size:
                 api_endpoint = f"https://{region_id}-aiplatform.googleapis.com/v1/projects/{self.project_id}/locations/{region_id}/notebookExecutionJobs?filter=schedule={schedule_id}&pageSize={page_size}&orderBy={order_by}"

--- a/scheduler_jupyter_plugin/tests/test_vertex.py
+++ b/scheduler_jupyter_plugin/tests/test_vertex.py
@@ -42,7 +42,7 @@ from scheduler_jupyter_plugin.tests.mocks import (
 async def test_get_schedule(monkeypatch, returncode, expected_result, jp_fetch):
     monkeypatch.setattr(aiohttp, "ClientSession", MockGetScheduleClientSession)
 
-    mock_region_id = "mock-region-id"
+    mock_region_id = "us-central1"
     mock_schedule_id = "mock-project-id"
 
     response = await jp_fetch(
@@ -59,7 +59,7 @@ async def test_get_schedule(monkeypatch, returncode, expected_result, jp_fetch):
 async def test_resume_schedule(monkeypatch, returncode, expected_result, jp_fetch):
     monkeypatch.setattr(aiohttp, "ClientSession", MockPostClientSession)
 
-    mock_region_id = "mock-region-id"
+    mock_region_id = "us-central1"
     mock_schedule_id = "mock-project-id"
 
     response = await jp_fetch(
@@ -78,7 +78,7 @@ async def test_resume_schedule(monkeypatch, returncode, expected_result, jp_fetc
 async def test_pause_schedule(monkeypatch, returncode, expected_result, jp_fetch):
     monkeypatch.setattr(aiohttp, "ClientSession", MockPostClientSession)
 
-    mock_region_id = "mock-region-id"
+    mock_region_id = "us-central1"
     mock_schedule_id = "mock-project-id"
 
     response = await jp_fetch(
@@ -99,7 +99,7 @@ async def test_pause_schedule(monkeypatch, returncode, expected_result, jp_fetch
 async def test_delete_schedule(monkeypatch, returncode, expected_result, jp_fetch):
     monkeypatch.setattr(aiohttp, "ClientSession", MockDeleteSchedulesClientSession)
 
-    mock_region_id = "mock-region-id"
+    mock_region_id = "us-central1"
     mock_schedule_id = "mock-project-id"
 
     response = await jp_fetch(
@@ -134,7 +134,7 @@ async def test_delete_schedule(monkeypatch, returncode, expected_result, jp_fetc
 async def test_list_uiconfig(monkeypatch, returncode, expected_result, jp_fetch):
     monkeypatch.setattr(aiohttp, "ClientSession", MockListUIConfigClientSession)
 
-    mock_region_id = "mock-region-id"
+    mock_region_id = "us-central1"
 
     response = await jp_fetch(
         "scheduler-plugin",
@@ -162,7 +162,7 @@ async def test_list_notebook_execution_jobs(
         aiohttp, "ClientSession", MockListNotebookExecutionJobsClientSession
     )
 
-    mock_region_id = "mock-region-id"
+    mock_region_id = "us-central1"
     mock_schedule_id = "mock-project-id"
     mock_order_by = "mock-order-by"
 
@@ -208,7 +208,7 @@ async def test_list_schedules(monkeypatch, returncode, expected_result, jp_fetch
     monkeypatch.setattr(vertex.Client, "parse_schedule", mock_get_description)
     monkeypatch.setattr(aiohttp, "ClientSession", MockListSchedulesClientSession)
 
-    mock_region_id = "mock-region-id"
+    mock_region_id = "us-central1"
     mock_page_size = "mock-page-size"
 
     response = await jp_fetch(
@@ -230,7 +230,7 @@ async def test_trigger_schedule(monkeypatch, returncode, expected_result, jp_fet
 
     monkeypatch.setattr(aiohttp, "ClientSession", MockTriggerSchedulesClientSession)
 
-    mock_region_id = "mock-region-id"
+    mock_region_id = "us-central1"
     mock_schedule_id = "mock-project-id"
 
     response = await jp_fetch(
@@ -388,3 +388,142 @@ class TestBuildShieldedInstanceConfig(unittest.TestCase):
                 "enableIntegrityMonitoring": False,
             },
         )
+
+
+MALICIOUS_REGION_IDS = [
+    "attacker.com/",
+    "169.254.169.254/",
+    "us-central1/",
+    "us-central1/../../evil",
+    "us-central1@evil.com",
+    "us-central1.evil.com",
+    "us-central1#frag",
+    "us-central1?a=b",
+    "US-CENTRAL1",
+    "localhost",
+    "",
+]
+
+
+class TestValidateRegionId(unittest.TestCase):
+    def test_valid_regions_pass(self):
+        for region in [
+            "us-central1",
+            "us-east4",
+            "us-west1",
+            "europe-west4",
+            "europe-west12",
+            "asia-northeast1",
+            "northamerica-northeast2",
+            "southamerica-east1",
+            "australia-southeast1",
+            "me-central1",
+            "africa-south1",
+        ]:
+            self.assertEqual(vertex.Client._validate_region_id(region), region)
+
+    def test_malicious_or_malformed_regions_raise(self):
+        for region in MALICIOUS_REGION_IDS + [None, "us_central1", "uscentral1"]:
+            with self.assertRaises(ValueError):
+                vertex.Client._validate_region_id(region)
+
+
+def _spy_client():
+    client = vertex.Client(
+        {
+            "access_token": "mock-token",
+            "project_id": "mock-project",
+            "region_id": "us-central1",
+        },
+        MagicMock(),
+        MagicMock(),
+    )
+    return client, client.client_session
+
+
+def _assert_no_outbound_request(session):
+    session.get.assert_not_called()
+    session.post.assert_not_called()
+    session.delete.assert_not_called()
+    session.patch.assert_not_called()
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_list_schedules_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.list_schedules(region, "10")
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_list_uiconfig_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.list_uiconfig(region)
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_get_schedule_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.get_schedule(region, "sched-1")
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_pause_schedule_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.pause_schedule(region, "sched-1")
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_resume_schedule_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.resume_schedule(region, "sched-1")
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_delete_schedule_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.delete_schedule(region, "sched-1")
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_trigger_schedule_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.trigger_schedule(region, "sched-1")
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_update_schedule_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.update_schedule(region, "sched-1", {})
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_list_notebook_execution_jobs_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    result = await client.list_notebook_execution_jobs(region, "sched-1", "createTime")
+    assert "Invalid region ID" in str(result)
+    _assert_no_outbound_request(session)
+
+
+@pytest.mark.parametrize("region", MALICIOUS_REGION_IDS)
+async def test_create_schedule_rejects_ssrf_region(region):
+    client, session = _spy_client()
+    job = DescribeVertexJob(region=region)
+    with pytest.raises(Exception):
+        await client.create_schedule(job, "gs://bucket/in.ipynb", "bucket")
+    _assert_no_outbound_request(session)


### PR DESCRIPTION
## Summary

Validate the Vertex `region_id` before it is used to build the outbound request
URL, preventing request forgery.

The Vertex handlers accept a `region_id` from the request and the service layer
(`scheduler_jupyter_plugin/services/vertex.py`) interpolates it directly into the
**host** of the outbound call
(`https://{region_id}-aiplatform.googleapis.com/...`). Because the value is not
validated, a `region_id` containing `/` (or `@`, etc.) terminates the URL
authority early and rebinds the request — which carries the user's
`Authorization: Bearer` credential — to an unintended host. Unlike the sibling
Airflow/executor handlers, the Vertex handlers performed no input validation.

## Changes

- Add `REGION_ID_REGEXP` to `commons/constants.py`.
- Add `Client._validate_region_id()` and call it at the single point where the
  request host is composed, so every affected method rejects a malformed region
  **before** issuing any outbound request:
  `list_uiconfig`, `list_schedules`, `get_schedule`,
  `list_notebook_execution_jobs`, `pause_schedule`, `resume_schedule`,
  `delete_schedule`, `trigger_schedule`, `update_schedule`, and
  `create_schedule` (region sourced from the request body).
- Tests: validator unit tests plus per-method regression tests asserting that a
  malformed region raises and that **no outbound request is attempted**; existing
  tests updated to use a valid region (`us-central1`).

## Testing

`pytest scheduler_jupyter_plugin/tests/test_vertex.py`

Ref: b/534408757
