### PR TITLE
Add using EUC as option instead of SA for execution identity

### DIFF
--- a/scheduler_jupyter_plugin/models/models.py
+++ b/scheduler_jupyter_plugin/models/models.py
@@ -77,7 +77,10 @@ class DescribeVertexJob(BaseModel):
     region: str = None
     cloud_storage_bucket: str = None
     parameters: Optional[List[str]] = None
+    # Execution identity. service_account and execution_user are the two arms of
+    # the NotebookExecutionJob execution_identity oneof, so exactly one is sent.
     service_account: str = None
+    execution_user: Optional[str] = None
     network: Optional[str] = None
     subnetwork: Optional[str] = None
     start_time: Optional[str] = None
@@ -122,7 +125,10 @@ class DescribeUpdateVertexJob(BaseModel):
     region: Optional[str] = None
     cloud_storage_bucket: Optional[str] = None
     parameters: Optional[List[str]] = None
+    # Execution identity. service_account and execution_user are the two arms of
+    # the NotebookExecutionJob execution_identity oneof, so exactly one is sent.
     service_account: Optional[str] = None
+    execution_user: Optional[str] = None
     network: Optional[str] = None
     subnetwork: Optional[str] = None
     start_time: Optional[str] = None

--- a/scheduler_jupyter_plugin/services/vertex.py
+++ b/scheduler_jupyter_plugin/services/vertex.py
@@ -147,6 +147,21 @@ class Client:
             }
         return None
 
+    def _apply_execution_identity(self, notebook_execution_job, job):
+        """Sets the execution identity on the notebook execution job in place.
+
+        `executionUser` (end-user credentials, EUC) and `serviceAccount` are the
+        two arms of the NotebookExecutionJob `execution_identity` oneof, so only
+        one may be sent. Sending both leaves the service to pick a winner, which
+        would silently run the notebook as an identity the user did not choose.
+        `executionUser` wins when set, matching the UI where picking EUC clears
+        the service account.
+        """
+        if job.execution_user:
+            notebook_execution_job["executionUser"] = job.execution_user
+        elif job.service_account:
+            notebook_execution_job["serviceAccount"] = job.service_account
+
     async def create_schedule(self, job, file_path, bucket_name):
         try:
             self._validate_region_id(job.region)
@@ -200,12 +215,15 @@ class Client:
                         },
                         "gcsNotebookSource": {"uri": notebook_source},
                         "gcsOutputUri": job.cloud_storage_bucket,
-                        "serviceAccount": job.service_account,
                         "kernelName": job.kernel_name,
                         "workbenchRuntime": workbench_runtime,
                     },
                 },
             }
+            self._apply_execution_identity(
+                payload["createNotebookExecutionJobRequest"]["notebookExecutionJob"],
+                job,
+            )
             shielded_instance_config = self._build_shielded_instance_config(job)
             if shielded_instance_config:
                 payload["createNotebookExecutionJobRequest"]["notebookExecutionJob"][
@@ -563,14 +581,18 @@ class Client:
                 param.split(":")[0]: param.split(":")[1] for param in data.parameters
             }
 
+            # EUC only activates when the job carries a kernel name, so losing
+            # it here would silently downgrade the schedule to the service
+            # agent. The update mask replaces the whole notebook execution job,
+            # so an absent key and an explicit null clear it alike; the create
+            # form already blocks saving without a kernel.
             if data.kernel_name:
                 notebook_execution_job["kernelName"] = data.kernel_name
             if data.kms_key_name:
                 notebook_execution_job["encryptionSpec"] = {
                     "kmsKeyName": data.kms_key_name
                 }
-            if data.service_account:
-                notebook_execution_job["serviceAccount"] = data.service_account
+            self._apply_execution_identity(notebook_execution_job, data)
             if data.cloud_storage_bucket:
                 notebook_execution_job["gcsOutputUri"] = data.cloud_storage_bucket
             if data.parameters:

--- a/scheduler_jupyter_plugin/tests/test_vertex.py
+++ b/scheduler_jupyter_plugin/tests/test_vertex.py
@@ -25,6 +25,8 @@ from scheduler_jupyter_plugin.models.models import (
 )
 from scheduler_jupyter_plugin.services import vertex
 from scheduler_jupyter_plugin.tests.mocks import (
+    MockClientSession,
+    MockResponse,
     MockDeleteSchedulesClientSession,
     MockGetScheduleClientSession,
     MockListNotebookExecutionJobsClientSession,
@@ -388,6 +390,163 @@ class TestBuildShieldedInstanceConfig(unittest.TestCase):
                 "enableIntegrityMonitoring": False,
             },
         )
+
+
+class TestApplyExecutionIdentity(unittest.TestCase):
+    """service_account and execution_user are a oneof, so only one is sent."""
+
+    def setUp(self):
+        self.client = _make_client()
+
+    def _apply(self, job):
+        notebook_execution_job = {}
+        self.client._apply_execution_identity(notebook_execution_job, job)
+        return notebook_execution_job
+
+    def test_service_account_only(self):
+        job = DescribeVertexJob(service_account="sa@project.iam.gserviceaccount.com")
+        self.assertEqual(
+            self._apply(job),
+            {"serviceAccount": "sa@project.iam.gserviceaccount.com"},
+        )
+
+    def test_execution_user_only(self):
+        job = DescribeVertexJob(execution_user="user@example.com")
+        self.assertEqual(self._apply(job), {"executionUser": "user@example.com"})
+
+    def test_both_set_sends_only_execution_user(self):
+        # Sending both arms of the oneof would let the service decide which
+        # identity the notebook runs as, so the chosen one must win outright.
+        job = DescribeVertexJob(
+            service_account="sa@project.iam.gserviceaccount.com",
+            execution_user="user@example.com",
+        )
+        self.assertEqual(self._apply(job), {"executionUser": "user@example.com"})
+
+    def test_neither_set_sends_nothing(self):
+        self.assertEqual(self._apply(DescribeVertexJob()), {})
+
+    def test_supports_update_model(self):
+        data = DescribeUpdateVertexJob(execution_user="user@example.com")
+        self.assertEqual(self._apply(data), {"executionUser": "user@example.com"})
+
+
+def _payload_client():
+    return vertex.Client(
+        {
+            "access_token": "mock-token",
+            "project_id": "mock-project",
+            "region_id": "us-central1",
+        },
+        MagicMock(),
+        MockClientSession(),
+    )
+
+
+def _base_job(**overrides):
+    fields = {
+        "display_name": "test-job",
+        "machine_type": "n1-standard-2 (2 CPUs, 8 GB RAM)",
+        "kernel_name": "python3",
+        "schedule_value": "* * * * *",
+        "time_zone": "UTC",
+        "region": "us-central1",
+        "cloud_storage_bucket": "gs://bucket",
+        "parameters": [],
+        "disk_type": "pd-standard (Standard Persistent Disk)",
+        "disk_size": "100",
+    }
+    fields.update(overrides)
+    return DescribeVertexJob(**fields)
+
+
+async def _created_execution_job(job):
+    client = _payload_client()
+    result = await client.create_schedule(job, "gs://bucket/n.ipynb", "bucket")
+    return result["results"][0]["json"]["createNotebookExecutionJobRequest"][
+        "notebookExecutionJob"
+    ]
+
+
+async def test_create_schedule_sends_execution_user_for_euc():
+    notebook_execution_job = await _created_execution_job(
+        _base_job(execution_user="user@example.com")
+    )
+
+    assert notebook_execution_job["executionUser"] == "user@example.com"
+    assert "serviceAccount" not in notebook_execution_job
+    # EUC only activates when the job carries a kernel name; without it the job
+    # succeeds while silently running as the service agent instead of the user.
+    assert notebook_execution_job["kernelName"] == "python3"
+
+
+async def test_create_schedule_sends_service_account_by_default():
+    notebook_execution_job = await _created_execution_job(
+        _base_job(service_account="sa@project.iam.gserviceaccount.com")
+    )
+
+    assert (
+        notebook_execution_job["serviceAccount"]
+        == "sa@project.iam.gserviceaccount.com"
+    )
+    assert "executionUser" not in notebook_execution_job
+
+
+async def test_create_schedule_omits_notebook_execution_job_id():
+    # A client-supplied non-numeric id makes the on-VM token exchange reject the
+    # resource name, leaving an EUC job stuck in PENDING with no error surfaced.
+    notebook_execution_job = await _created_execution_job(
+        _base_job(execution_user="user@example.com")
+    )
+
+    assert "notebookExecutionJobId" not in notebook_execution_job
+
+
+class _PatchCapturingSession:
+    """Captures the body of the PATCH that update_schedule sends."""
+
+    def __init__(self):
+        self.json_body = None
+
+    def patch(self, api_endpoint, headers=None, json=None):
+        self.json_body = json
+        return MockResponse({})
+
+
+async def test_update_schedule_always_sends_kernel_name():
+    session = _PatchCapturingSession()
+    client = vertex.Client(
+        {
+            "access_token": "mock-token",
+            "project_id": "mock-project",
+            "region_id": "us-central1",
+        },
+        MagicMock(),
+        session,
+    )
+
+    await client.update_schedule(
+        "us-central1",
+        "projects/p/locations/us-central1/schedules/1",
+        {
+            "display_name": "test-job",
+            "kernel_name": "python3",
+            "schedule_value": "* * * * *",
+            "time_zone": "UTC",
+            "parameters": [],
+            "execution_user": "user@example.com",
+            "gcs_notebook_source": "gs://bucket/n.ipynb",
+        },
+    )
+
+    notebook_execution_job = session.json_body["createNotebookExecutionJobRequest"][
+        "notebookExecutionJob"
+    ]
+    # Unconditional: an edit that drops the kernel name turns an EUC schedule
+    # back into one that silently runs as the service agent.
+    assert notebook_execution_job["kernelName"] == "python3"
+    assert notebook_execution_job["executionUser"] == "user@example.com"
+    assert "serviceAccount" not in notebook_execution_job
 
 
 MALICIOUS_REGION_IDS = [

--- a/src/__tests__/EucConsentError.spec.ts
+++ b/src/__tests__/EucConsentError.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { extractEucConsentUrl } from '../utils/EucConsentError';
+
+const CONSENT_URL =
+  'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&response_type=none+gsession&client_id=1057398310658-abc.apps.googleusercontent.com&redirect_uri=https%3A%2F%2Fnotebooks.cloud.google.com%2Fstatic%2Foauth.html&login_hint=user%40example.com';
+
+const DOCS_URL =
+  'https://cloud.google.com/colab/docs/run-code-adc#end-user-credentials';
+
+const consentErrorBody = {
+  error: {
+    code: 401,
+    status: 'UNAUTHENTICATED',
+    message:
+      "You must grant Colab Enterprise consent to create a NotebookExecutionJob with 'user@example.com' as an execution identity. " +
+      `See ${DOCS_URL} for more details on how to grant consent.`,
+    details: [
+      {
+        '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+        reason: 'EUC_CONSENT_REQUIRED',
+        domain: 'aiplatform.googleapis.com',
+        metadata: { oauthUri: CONSENT_URL }
+      }
+    ]
+  }
+};
+
+describe('extractEucConsentUrl', () => {
+  it('reads the consent URL from a structured error object', () => {
+    expect(extractEucConsentUrl(consentErrorBody)).toEqual(CONSENT_URL);
+  });
+
+  it('reads the consent URL out of the flattened error string', () => {
+    // The backend collapses the whole response body into one string before it
+    // reaches the frontend, so this is the shape actually seen at runtime.
+    const flattened = `Error creating schedule: Unauthorized ${JSON.stringify(
+      consentErrorBody
+    )}`;
+
+    expect(extractEucConsentUrl(flattened)).toEqual(CONSENT_URL);
+  });
+
+  it('never returns the documentation link instead of the consent link', () => {
+    // The same error carries a docs URL in its message. Returning that would
+    // send the user to a page that leaves them exactly as stuck as before.
+    const flattened = `Error creating schedule: Unauthorized ${JSON.stringify(
+      consentErrorBody
+    )}`;
+
+    expect(extractEucConsentUrl(flattened)).not.toContain(
+      'cloud.google.com/colab/docs'
+    );
+  });
+
+  it('returns undefined for an unrelated error', () => {
+    const permissionDenied = {
+      error: {
+        code: 403,
+        status: 'PERMISSION_DENIED',
+        message:
+          "Provided execution_user 'other@example.com' should match the authenticated user 'user@example.com'."
+      }
+    };
+
+    expect(extractEucConsentUrl(permissionDenied)).toBeUndefined();
+    expect(
+      extractEucConsentUrl(JSON.stringify(permissionDenied))
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an error that only mentions the docs URL', () => {
+    expect(
+      extractEucConsentUrl(`Error creating schedule: see ${DOCS_URL}`)
+    ).toBeUndefined();
+  });
+
+  it('handles empty and malformed input without throwing', () => {
+    expect(extractEucConsentUrl('')).toBeUndefined();
+    expect(extractEucConsentUrl(undefined)).toBeUndefined();
+    expect(extractEucConsentUrl('{not json')).toBeUndefined();
+  });
+});

--- a/src/scheduler/vertex/CreateVertexScheduler.tsx
+++ b/src/scheduler/vertex/CreateVertexScheduler.tsx
@@ -50,12 +50,16 @@ import {
   DEFAULT_DISK_MIN_SIZE,
   DEFAULT_DISK_SIZE,
   DEFAULT_ENCRYPTION_SELECTED,
+  DEFAULT_EXECUTION_IDENTITY,
   DEFAULT_IMAGE_ENVIRONMENT,
   DEFAULT_KERNEL,
   DEFAULT_MACHINE_TYPE,
   DEFAULT_SERVICE_ACCOUNT,
   DISK_TYPE_VALUE,
+  EUC_DOC_URL,
   everyMinuteCron,
+  EXECUTION_IDENTITY_SERVICE_ACCOUNT,
+  EXECUTION_IDENTITY_USER,
   IMAGE_ENVIRONMENT_CONTAINER,
   IMAGE_ENVIRONMENT_DEFAULT,
   IMAGE_ENVIRONMENT_VM_IMAGE,
@@ -255,6 +259,13 @@ const CreateVertexScheduler = ({
     useState<string>('');
   const [customContainerTag, setCustomContainerTag] = useState<string>('');
 
+  // Execution identity. The two values are the arms of the API's
+  // execution_identity oneof, so selecting one clears the other.
+  const [executionIdentity, setExecutionIdentity] = useState<string>(
+    DEFAULT_EXECUTION_IDENTITY
+  );
+  const [executionUser, setExecutionUser] = useState<string>('');
+
   // Shielded VM options for the execution VM (all disabled by default).
   const [enableSecureBoot, setEnableSecureBoot] = useState<boolean>(false);
   const [enableVtpm, setEnableVtpm] = useState<boolean>(false);
@@ -374,6 +385,27 @@ const CreateVertexScheduler = ({
       | null
   ) => {
     setServiceAccountSelected(value);
+  };
+
+  /**
+   * Handles the execution identity selection.
+   *
+   * The API models the service account and the execution user as a oneof, so
+   * the field belonging to the identity that was not chosen is cleared here.
+   * That keeps the payload unambiguous and stops a stale value from a previous
+   * selection being sent.
+   * @param {React.ChangeEvent<HTMLInputElement>} event the radio change event
+   */
+  const handleExecutionIdentityChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = event.target.value;
+    setExecutionIdentity(value);
+    if (value === EXECUTION_IDENTITY_USER) {
+      setServiceAccountSelected(null);
+    } else {
+      setExecutionUser('');
+    }
   };
 
   /**
@@ -862,7 +894,10 @@ const CreateVertexScheduler = ({
       (acceleratorType && !acceleratedCount) ||
       kernelSelected === null ||
       cloudStorage === null ||
-      serviceAccountSelected === null ||
+      // Exactly one arm of the execution_identity oneof must be filled in.
+      (executionIdentity === EXECUTION_IDENTITY_USER
+        ? executionUser.trim() === ''
+        : serviceAccountSelected === null) ||
       (networkSelected === 'networkInThisProject' &&
         subNetworkSelected &&
         (primaryNetworkSelected === null ||
@@ -926,7 +961,16 @@ const CreateVertexScheduler = ({
       max_run_count: scheduleMode === 'runNow' ? '1' : maxRuns,
       region: region,
       cloud_storage_bucket: `gs://${cloudStorage}`,
-      service_account: serviceAccountSelected?.email,
+      // Only the selected arm of the execution_identity oneof is sent; the
+      // other stays undefined so the backend never has to pick a winner.
+      service_account:
+        executionIdentity === EXECUTION_IDENTITY_USER
+          ? undefined
+          : serviceAccountSelected?.email,
+      execution_user:
+        executionIdentity === EXECUTION_IDENTITY_USER
+          ? executionUser.trim()
+          : undefined,
       network:
         networkSelected === 'networkInThisProject'
           ? editMode
@@ -1150,6 +1194,16 @@ const CreateVertexScheduler = ({
         );
       } else {
         setImageEnvironmentSelected(IMAGE_ENVIRONMENT_DEFAULT);
+      }
+
+      // Load the execution identity. Only one arm of the oneof comes back, so
+      // an execution user on the schedule means it was created with EUC.
+      if (vertexSchedulerDetails.execution_user) {
+        setExecutionIdentity(EXECUTION_IDENTITY_USER);
+        setExecutionUser(vertexSchedulerDetails.execution_user);
+      } else {
+        setExecutionIdentity(EXECUTION_IDENTITY_SERVICE_ACCOUNT);
+        setExecutionUser('');
       }
 
       // Load Shielded VM options.
@@ -1728,51 +1782,126 @@ const CreateVertexScheduler = ({
             <LearnMore path={SHIELDED_VM_DOC_URL} />
           </div>
 
-          <div className="create-scheduler-form-element panel-margin block-seperation">
-            <Autocomplete
-              className="create-scheduler-style-trigger"
-              options={serviceAccountList}
-              getOptionLabel={option => option.displayName}
-              value={
-                serviceAccountList.find(
-                  option => option.email === serviceAccountSelected?.email
-                ) || null
-              }
-              clearIcon={false}
-              loading={serviceAccountLoading}
-              onChange={(_event, val) => handleServiceAccountChange(val)}
-              renderInput={params => (
-                <TextField {...params} label="Service account*" />
-              )}
-              renderOption={(props, option) => (
-                <Box
-                  component="li"
-                  {...props}
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'flex-start'
-                  }}
-                >
-                  <Typography variant="body1">{option.displayName}</Typography>
-                  <Typography variant="body2" color="textSecondary">
-                    {option.email}
-                  </Typography>
-                </Box>
-              )}
-            />
+          <div className="create-job-scheduler-text-para create-job-scheduler-sub-title">
+            Execution identity
           </div>
-          {!serviceAccountSelected && !errorMessageServiceAccount && (
-            <ErrorMessage
-              message="Service account is required"
-              showIcon={false}
-            />
-          )}
 
-          {errorMessageServiceAccount && (
-            <span className="error-message-warn error-key-missing">
-              {errorMessageServiceAccount}
-            </span>
+          <div className="create-scheduler-form-element panel-margin">
+            <FormControl>
+              <RadioGroup
+                aria-labelledby="execution-identity-radio-buttons-group"
+                name="execution-identity-radio-buttons-group"
+                value={executionIdentity}
+                onChange={handleExecutionIdentityChange}
+                data-testid={`${executionIdentity}-selected`}
+              >
+                <FormControlLabel
+                  value={EXECUTION_IDENTITY_SERVICE_ACCOUNT}
+                  className="create-scheduler-label-style"
+                  control={<Radio size="small" />}
+                  label={
+                    <Typography sx={{ fontSize: 13 }}>
+                      Service account
+                    </Typography>
+                  }
+                />
+                <span className="sub-para tab-text-sub-cl encryption-radio">
+                  The notebook runs with the permissions of the selected service
+                  account
+                </span>
+                <FormControlLabel
+                  value={EXECUTION_IDENTITY_USER}
+                  className="create-scheduler-label-style"
+                  control={<Radio size="small" />}
+                  label={
+                    <Typography sx={{ fontSize: 13 }}>
+                      User credentials
+                    </Typography>
+                  }
+                />
+                <span className="sub-para tab-text-sub-cl encryption-radio">
+                  The notebook runs as the user below, and can only access what
+                  they can access. The user must be the account this plugin is
+                  authenticated as, and must have granted consent.
+                </span>
+              </RadioGroup>
+            </FormControl>
+          </div>
+
+          <div className="learn-more-a-tag learn-more-url">
+            <LearnMore path={EUC_DOC_URL} />
+          </div>
+
+          {executionIdentity === EXECUTION_IDENTITY_SERVICE_ACCOUNT ? (
+            <>
+              <div className="create-scheduler-form-element panel-margin block-seperation">
+                <Autocomplete
+                  className="create-scheduler-style-trigger"
+                  options={serviceAccountList}
+                  getOptionLabel={option => option.displayName}
+                  value={
+                    serviceAccountList.find(
+                      option => option.email === serviceAccountSelected?.email
+                    ) || null
+                  }
+                  clearIcon={false}
+                  loading={serviceAccountLoading}
+                  onChange={(_event, val) => handleServiceAccountChange(val)}
+                  renderInput={params => (
+                    <TextField {...params} label="Service account*" />
+                  )}
+                  renderOption={(props, option) => (
+                    <Box
+                      component="li"
+                      {...props}
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'flex-start'
+                      }}
+                    >
+                      <Typography variant="body1">
+                        {option.displayName}
+                      </Typography>
+                      <Typography variant="body2" color="textSecondary">
+                        {option.email}
+                      </Typography>
+                    </Box>
+                  )}
+                />
+              </div>
+              {!serviceAccountSelected && !errorMessageServiceAccount && (
+                <ErrorMessage
+                  message="Service account is required"
+                  showIcon={false}
+                />
+              )}
+
+              {errorMessageServiceAccount && (
+                <span className="error-message-warn error-key-missing">
+                  {errorMessageServiceAccount}
+                </span>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="create-scheduler-form-element panel-margin block-seperation">
+                <Input
+                  className="create-scheduler-style"
+                  value={executionUser}
+                  onChange={e => setExecutionUser(e.target.value)}
+                  type="text"
+                  placeholder="user@example.com"
+                  Label="User email*"
+                />
+              </div>
+              {executionUser.trim() === '' && (
+                <ErrorMessage
+                  message="User email is required"
+                  showIcon={false}
+                />
+              )}
+            </>
           )}
 
           <div className="create-job-scheduler-text-para create-job-scheduler-sub-title">

--- a/src/scheduler/vertex/VertexInterfaces.ts
+++ b/src/scheduler/vertex/VertexInterfaces.ts
@@ -39,7 +39,10 @@ export interface ICreatePayload {
   region: string;
   cloud_storage_bucket: string | null;
   parameters?: string[];
+  // Execution identity: service_account and execution_user are the two arms of
+  // the NotebookExecutionJob execution_identity oneof, so only one is ever set.
   service_account: any | undefined;
+  execution_user?: string;
   network?: any | undefined;
   subnetwork?: any | undefined;
   shared_network?: any;

--- a/src/services/Vertex.tsx
+++ b/src/services/Vertex.tsx
@@ -44,7 +44,8 @@ import {
 } from '../utils/Const';
 import React, { Dispatch, SetStateAction } from 'react';
 import ExpandToastMessage from '../scheduler/common/ExpandToastMessage';
-import { handleErrorToast } from '../utils/ErrorUtils';
+import { handleErrorToast, handleEucConsentToast } from '../utils/ErrorUtils';
+import { extractEucConsentUrl } from '../utils/EucConsentError';
 
 export class VertexServices {
   static readonly machineTypeAPIService = (
@@ -122,9 +123,16 @@ export class VertexServices {
         method: 'POST'
       });
       if (data.error) {
-        handleErrorToast({
-          error: data.error
-        });
+        // A missing-consent rejection carries the OAuth URL the user needs, so
+        // link them to it instead of showing the bare error they cannot act on.
+        const consentUrl = extractEucConsentUrl(data.error);
+        if (consentUrl) {
+          handleEucConsentToast(consentUrl);
+        } else {
+          handleErrorToast({
+            error: data.error
+          });
+        }
         setCreatingVertexScheduler(false);
       } else {
         Notification.success(
@@ -172,9 +180,16 @@ export class VertexServices {
         }
       );
       if (data.error) {
-        handleErrorToast({
-          error: data.error
-        });
+        // Editing a schedule can hit the same missing-consent rejection as
+        // creating one, so it gets the same actionable link.
+        const consentUrl = extractEucConsentUrl(data.error);
+        if (consentUrl) {
+          handleEucConsentToast(consentUrl);
+        } else {
+          handleErrorToast({
+            error: data.error
+          });
+        }
         setCreatingVertexScheduler(false);
       } else {
         Notification.success(
@@ -645,6 +660,11 @@ export class VertexServices {
               formattedResponse.createNotebookExecutionJobRequest
                 .notebookExecutionJob.serviceAccount
           },
+          // Only one arm of the execution_identity oneof comes back, so this is
+          // set exactly when the schedule was created to run as a user.
+          execution_user:
+            formattedResponse.createNotebookExecutionJobRequest
+              .notebookExecutionJob.executionUser,
           network: {
             name: primaryNetwork
               ? primaryNetwork[primaryNetwork.length - 1]

--- a/src/utils/Const.ts
+++ b/src/utils/Const.ts
@@ -197,6 +197,18 @@ export const DEFAULT_CONTAINER_IMAGE_TAG = 'latest';
 export const SHIELDED_VM_DOC_URL =
   'https://cloud.google.com/compute/docs/instances/modifying-shielded-vm';
 
+// Execution identity selection. These are the two arms of the
+// NotebookExecutionJob execution_identity oneof, so exactly one is ever sent.
+export const EXECUTION_IDENTITY_SERVICE_ACCOUNT = 'serviceAccount';
+export const EXECUTION_IDENTITY_USER = 'executionUser';
+export const DEFAULT_EXECUTION_IDENTITY = EXECUTION_IDENTITY_SERVICE_ACCOUNT;
+
+export const EUC_DOC_URL =
+  'https://cloud.google.com/colab/docs/run-code-adc#end-user-credentials';
+
+export const EUC_CONSENT_MESSAGE =
+  'This user has not granted consent to run notebooks with their credentials. Grant consent, then refresh this browser tab and create the schedule again.';
+
 export const INPUT_HELPER_TEXT =
   'This schedule will run a copy of this notebook in its current state. If you edit the original notebook, you must create a new schedule to run the updated version of the notebook.';
 export const NO_EXECUTION_FOUND =

--- a/src/utils/ErrorUtils.tsx
+++ b/src/utils/ErrorUtils.tsx
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 import { Notification } from '@jupyterlab/apputils';
 import ExpandToastMessage from '../scheduler/common/ExpandToastMessage';
 import { toastifyCustomStyle, toastifyCustomWidth } from './Config';
+import { EUC_CONSENT_MESSAGE } from './Const';
 
 // Recursively search for a 'message' key in an object
 function findMessage(obj: any): string | undefined {
@@ -30,6 +31,25 @@ export function extractUrls(text: string): string[] {
   const urlPattern =
     /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
   return text.match(urlPattern) || [];
+}
+
+/**
+ * Shows the missing-consent error as a toast linking to the consent screen.
+ *
+ * Consent is granted in a separate browser tab and nothing calls back into
+ * JupyterLab, so the message tells the user to refresh before retrying.
+ * @param consentUrl - the OAuth consent URL returned by the API
+ */
+export function handleEucConsentToast(consentUrl: string) {
+  toast.error(
+    <div>
+      {EUC_CONSENT_MESSAGE}{' '}
+      <a href={consentUrl} target="_blank" rel="noopener noreferrer">
+        Grant consent
+      </a>
+    </div>,
+    toastifyCustomWidth
+  );
 }
 
 /**

--- a/src/utils/EucConsentError.ts
+++ b/src/utils/EucConsentError.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Deliberately free of imports so this parsing can be unit tested without
+// pulling in the UI toolchain, or Const.ts and its require() of package.json.
+
+// Reason code on the google.rpc.ErrorInfo the API attaches to its
+// UNAUTHENTICATED response when the execution user has not granted consent.
+export const EUC_CONSENT_REQUIRED_REASON = 'EUC_CONSENT_REQUIRED';
+
+// Matches the OAuth consent URL the API returns when the execution user has not
+// granted consent. Anchored on the OAuth endpoint rather than matching any URL:
+// the same error also carries a documentation link, and sending the user there
+// leaves them exactly as stuck as before.
+export const OAUTH_CONSENT_URL_PATTERN =
+  /https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?[^\s"'\\]+/;
+
+// Parse a JSON object out of an error, which reaches the frontend as a string
+// with the API's response body embedded in it.
+function parseErrorJson(error: any): any {
+  if (typeof error !== 'string') {
+    return error;
+  }
+  const jsonStart = error.indexOf('{');
+  const jsonEnd = error.lastIndexOf('}');
+  if (jsonStart === -1 || jsonEnd === -1) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(error.slice(jsonStart, jsonEnd + 1));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns the OAuth consent URL when an error is the API's "execution user has
+ * not granted consent" rejection, or undefined for every other error.
+ *
+ * The API reports this as UNAUTHENTICATED with a google.rpc.ErrorInfo detail
+ * carrying the URL, so the reason code is matched first. The regex fallback
+ * exists because the whole response is flattened into a string on its way here,
+ * and it is anchored on the OAuth endpoint on purpose: the same error also
+ * carries a documentation link, and sending the user there would leave them
+ * exactly as stuck as before.
+ * @param error - error string or object from the create/update call
+ */
+export function extractEucConsentUrl(error: any): string | undefined {
+  const errorObj = parseErrorJson(error);
+  const details = errorObj?.error?.details ?? errorObj?.details;
+  if (Array.isArray(details)) {
+    for (const detail of details) {
+      if (detail?.reason === EUC_CONSENT_REQUIRED_REASON) {
+        const url = detail?.metadata?.oauthUri;
+        if (typeof url === 'string' && url) {
+          return url;
+        }
+      }
+    }
+  }
+
+  const errorStr = typeof error === 'string' ? error : JSON.stringify(error);
+  if (!errorStr || !errorStr.includes(EUC_CONSENT_REQUIRED_REASON)) {
+    return undefined;
+  }
+  return errorStr.match(OAUTH_CONSENT_URL_PATTERN)?.[0];
+}


### PR DESCRIPTION
## Add end-user credentials (EUC) as an execution identity option for Vertex schedules
### What
Adds a **User credentials** option alongside the existing service account selector, so a scheduled notebook can run as the submitting user instead of a service account. When the user hasn't granted OAuth consent, the resulting error is turned into a clickable consent link rather than an unactionable wall of text.
### Why
The Vertex AI API supports `execution_user` on `NotebookExecutionJob`, and running a notebook under end-user credentials means it can only access what that user can access, rather than inheriting a service account's permissions. The plugin previously only ever sent `service_account`, so there was no way to reach EUC at all.
The second half is consent. Vertex requires a one-time OAuth grant before it will run a job as a user, and without it `CreateNotebookExecutionJob` fails with a bare `UNAUTHENTICATED` and a documentation link — a dead end for a first-time user. The API attaches the consent URL to that error as `google.rpc.ErrorInfo` metadata; this change consumes it and surfaces it as a link.
### How
**Execution identity is a `oneof`.** `execution_user` and `service_account` are the two arms of `NotebookExecutionJob.execution_identity`, so exactly one may be sent. The UI enforces this with a radio group that clears the other field on switch, and the backend enforces it in `_apply_execution_identity()`, shared by the create and update paths.
**Consent errors are detected by reason code, not URL shape.** `extractEucConsentUrl()` matches `reason == "EUC_CONSENT_REQUIRED"` and reads `metadata.oauthUri`. It falls back to a regex because the plugin backend flattens the whole response into a string on its way to the frontend — and that regex is *anchored on the OAuth endpoint* on purpose: the same error also carries a documentation link, and linking the user there would leave them exactly as stuck as before. There's a test pinning that behavior.
Any other failure — notably `PERMISSION_DENIED` when `execution_user` doesn't match the authenticated caller — falls through to the normal error display, since a consent link cannot resolve it.
The parser lives in its own dependency-free module so it can be unit tested without pulling in the JupyterLab/React toolchain.
### Files
| File | Change |
|---|---|
| `models/models.py` | `execution_user` on both job models |
| `services/vertex.py` | `_apply_execution_identity()`, used by create + update |
| `CreateVertexScheduler.tsx` | identity radio group, email field, validation, edit-mode reload |
| `VertexInterfaces.ts` | `execution_user` on `ICreatePayload` |
| `services/Vertex.tsx` | consent handling on create + edit; `execution_user` read-back |
| `utils/EucConsentError.ts` *(new)* | consent-URL extraction |
| `utils/ErrorUtils.tsx` | consent toast with link |
| `utils/Const.ts` | identity constants, doc URL, consent copy |
| `tests/test_vertex.py`, `EucConsentError.spec.ts` *(new)* | tests |
### Testing
`169 pytest`, `7 jest`, `tsc`, `jlpm run lint`, and `jlpm build` all pass.
Backend tests cover oneof exclusivity in both directions, both-set precedence, the built create payload for each identity, and that `notebookExecutionJobId` is never sent — a client-supplied non-numeric job id causes the on-VM token exchange to reject the resource name, stalling the job in `PENDING` with no error surfaced, so it is worth keeping pinned.
Frontend tests cover structured and flattened error shapes, unrelated errors, malformed input, and the documentation-URL guard.
Manually verified in JupyterLab: the selector renders and toggles correctly, fields clear on switch, Create stays disabled until an identity is supplied, and the consent toast renders with a working link.
### Known gaps
- **Not yet exercised against a live 401.** Manual testing used a stubbed error response. The generated link reached Google's OAuth endpoint and was rejected only because the stub carried a placeholder `client_id`, which confirms the URL is well formed and correctly distinguished from the documentation link — but the real consent round trip still needs a run from an environment whose credentials can reach the Vertex AI API.
- **Consent is per environment.** Each environment has its own OAuth client, so granting consent against one does not carry over to another. Relevant when testing across projects or endpoints.
- **Post-consent requires a manual refresh.** Consent is granted in a separate browser tab with no callback into JupyterLab, so the message tells the user to refresh and retry.

### Manual Testing 
Hardcoded an error result to simulate an EUC consent failure. 
<img width="963" height="1194" alt="image" src="https://github.com/user-attachments/assets/4178cba0-69b8-4cf3-8555-8fcb4efc46c5" />
<img width="2549" height="1028" alt="image" src="https://github.com/user-attachments/assets/78a15d3d-2168-4b80-9b45-3d6ee399e016" />
